### PR TITLE
create outlined text (as in the logo) and updated nav

### DIFF
--- a/src/components/astro/Navbar.astro
+++ b/src/components/astro/Navbar.astro
@@ -1,6 +1,5 @@
 ---
-import { Image } from 'astro:assets'
-import Logo from '@assets/logos/logo.svg'
+import OutlinedText from './OutlinedText.astro'
 import { cn } from '@utils/cn'
 
 interface Props {
@@ -63,16 +62,19 @@ const navLinks = [
 
       <!-- Logo  -->
       <a href="/" class="flex items-center">
-        <Image
-          src={Logo}
-          width={96}
-          height={96}
-          quality={100}
-          loading="eager"
-          format="webp"
-          alt="לא טכני"
-          class="size-14"
-        />
+        <div>
+          <div class="flex items-center gap-1.5">
+            <OutlinedText className="text-xs md:text-sm">&lt;</OutlinedText>
+            <OutlinedText className="text-base md:text-lg lg:text-xl" underline>לא</OutlinedText>
+            <OutlinedText className="text-lg md:text-xl lg:text-2xl">טכני</OutlinedText>
+          </div>
+
+          <div class="flex items-center gap-1.5 ps-4">
+            <OutlinedText className="text-base md:text-lg lg:text-xl" underline>ולא</OutlinedText>
+            <OutlinedText className="text-lg md:text-xl lg:text-2xl">במקרה </OutlinedText>
+            <OutlinedText className="text-xs md:text-sm">\&gt;</OutlinedText>
+          </div>
+        </div>
       </a>
 
       <!-- Mobile Menu - button -->

--- a/src/components/astro/OutlinedText.astro
+++ b/src/components/astro/OutlinedText.astro
@@ -1,0 +1,29 @@
+---
+import { cn } from '@utils/cn'
+import type { HTMLTag, HTMLAttributes } from 'astro/types'
+
+type ValidTags = 'span' | 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+
+interface Props extends HTMLAttributes<'span'> {
+  className?: string
+  underline?: boolean
+  tag?: ValidTags
+}
+
+const { className, underline = false, tag = 'span', ...rest } = Astro.props
+
+const Tag = tag as HTMLTag
+---
+
+<Tag
+  class={cn(
+    'inline-block font-bold text-white',
+    '[text-shadow:_-1px_-1px_0_#000,_1px_-1px_0_#000,_-1px_1px_0_#000,_1px_1px_0_#000]',
+    {
+      '-mt-[0.15em] underline underline-offset-4': underline,
+    },
+    className
+  )}
+  {...rest}>
+  <slot />
+</Tag>


### PR DESCRIPTION
> TLDR;
> - Refactor Navbar component to replace logo with outlined text elements for improved visual presentation.
> - Removed unused image imports and updated the structure to enhance accessibility and styling consistency.

Hey @adirkandel @talmosko 
That's something came into my mind for (maybe?) better handeling the Navbar logo and text/image for certain cards text.

i was going through [PR #15](https://github.com/talmosko/lotechni.dev/pull/15) and i saw the images we imported.

I dont think they are super crisp/sharp and thought we can use some dynamic text for it instead of specific image.
they are very simple, just round div/divs with some text)

Also i have replaced  the Navbar logo (which has very small-hard to read details and create a version of the main logo _(just the "lo thecni ve lo bemikre" string with the </> tags)_

This is just a suggestion, if you think this is helpfull then lets add it. if its not we can discard it.
up to you

Previews:

general use:
![Cursor 2025-01-07 00 23 12](https://github.com/user-attachments/assets/f700d1c2-9332-4812-bcc9-7015c5ef7236)

Navbar desktop:
![Cursor 2025-01-07 00 23 11](https://github.com/user-attachments/assets/ce18a2ca-6cb5-49ee-b8d3-ce91daf1a4e3)

navbar mobile:
![Cursor 2025-01-07 00 23 10](https://github.com/user-attachments/assets/4a1b99a2-72d6-48dc-99a0-069ce9e47923)

we can polish it to be more "pixel perfect" to the font weight and spacing as the logo. but generally this is very similar looking.

Let me know what do you think.

[here is the image i opened from PR#15 as reference
](https://pps.whatsapp.net/v/t61.24694-24/437708221_456588560461081_4651990565380993545_n.jpg?ccb=11-4&oh=01_Q5AaIKIyffpZCpof_MhuwdDBiYWK9jHxJTc2R5OFg5BOoTQY&oe=677F8734&_nc_sid=5e03e0&_nc_cat=105)