### PR TITLE
Add Carousel component with Blaze Slider

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^19.0.7",
     "@types/react-dom": "^19.0.3",
     "astro": "^5.1.8",
+    "blaze-slider": "^1.9.3",
     "clsx": "^2.1.1",
     "fast-xml-parser": "^4.5.1",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       astro:
         specifier: ^5.1.8
         version: 5.1.8(@types/node@22.10.7)(jiti@2.4.2)(rollup@4.31.0)(typescript@5.7.3)(yaml@2.7.0)
+      blaze-slider:
+        specifier: ^1.9.3
+        version: 1.9.3
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1188,6 +1191,9 @@ packages:
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  blaze-slider@1.9.3:
+    resolution: {integrity: sha512-u8i4AhbjICF6gpyKeMEg65kupT2JoN+E7yOJjOt3ocUtS+r4SKYU79DPNSBV2Zb61fix4ChIxfPyyRUSmLao5g==}
 
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
@@ -4878,6 +4884,8 @@ snapshots:
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+
+  blaze-slider@1.9.3: {}
 
   boxen@8.0.1:
     dependencies:

--- a/src/components/astro/Carousel.astro
+++ b/src/components/astro/Carousel.astro
@@ -1,0 +1,115 @@
+---
+import { cn } from '@utils/cn'
+import Icon from '@components/astro/Icon.astro'
+import Heading from '@components/astro/typography/Heading.astro'
+
+export interface Props {
+  sectionTitle?: string
+  sectionLink?: string
+  showPagination?: boolean
+  duration?: number
+  slidesByWidth?: { mobile: number; md?: number; lg?: number }
+  group?: boolean
+  autoPlay?: boolean
+  autoplayInterval?: number
+  hideTitle?: boolean
+  hideControls?: boolean
+  hideTop?: boolean
+  paginationClasses?: string
+}
+
+const {
+  sectionTitle = 'Default Title',
+  sectionLink = null,
+  showPagination = true,
+  duration = 600,
+  slidesByWidth = { mobile: 1, md: 2, lg: 3 },
+  group = true,
+  autoPlay = false,
+  autoplayInterval = 5000,
+  hideTitle = false,
+  hideControls = false,
+  hideTop = false,
+  paginationClasses = '',
+} = Astro.props
+
+const { mobile, md, lg } = slidesByWidth
+---
+
+<div
+  class="blaze-slider"
+  data-duration={JSON.stringify(duration)}
+  data-slides={JSON.stringify(slidesByWidth)}
+  data-group={JSON.stringify(group)}
+  data-autoplay={JSON.stringify(autoPlay)}
+  data-autoplay-interval={JSON.stringify(autoplayInterval)}>
+  <div class="blaze-container">
+    <div class={cn('mb-6 flex w-full items-center justify-between', hideTop && 'hidden')}>
+      {
+        sectionLink ? (
+          <a
+            href={sectionLink}
+            class={cn(
+              'mr-auto flex w-full items-center justify-between text-2xl font-bold hover:text-accent md:justify-start',
+              hideTitle && 'hidden'
+            )}>
+            <Heading level={2} className="pb-1">
+              {sectionTitle}
+            </Heading>
+          </a>
+        ) : (
+          <Heading level={2} className="pb-1">
+            {sectionTitle}
+          </Heading>
+        )
+      }
+
+      <div class={cn('ml-auto hidden gap-4 md:flex', hideControls && 'md:hidden')}>
+        <!-- navigation buttons -->
+        <button
+          class="blaze-prev rounded-full hover:text-accent focus:outline-none"
+          aria-label="Go to previous slide"
+          id="scrollLeft">
+          <Icon icon="chevronLeft" className="size-8" />
+        </button>
+        <button
+          id="scrollRight"
+          class="blaze-next rounded-full hover:text-accent focus:outline-none"
+          aria-label="Go to next slide">
+          <Icon icon="chevronRight" className="size-8" />
+        </button>
+      </div>
+    </div>
+    <div class="blaze-track-container">
+      <div class="blaze-track">
+        <slot />
+      </div>
+      <!-- pagination container -->
+      <div
+        class={cn(
+          'blaze-pagination [&>button]:aria-hidden flex justify-center gap-2 py-4 text-[2px] text-transparent [&>button.active]:bg-accent [&>button]:size-2.5 [&>button]:rounded-full [&>button]:bg-surface',
+          !showPagination && 'hidden',
+          paginationClasses
+        )}>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style define:vars={{ mobile, md, lg }}>
+  .blaze-slider {
+    --slides-to-show: var(--mobile);
+  }
+
+  @media (min-width: 768px) {
+    .blaze-slider {
+      --slides-to-show: var(--md);
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .blaze-slider {
+      --slides-to-show: var(--lg);
+    }
+  }
+</style>

--- a/src/components/astro/Footer.astro
+++ b/src/components/astro/Footer.astro
@@ -2,7 +2,7 @@
 import SectionContainer from '@components/astro/containers/SectionContainer.astro'
 import Icon from '@components/astro/Icon.astro'
 import type { IconNames } from '@data/types/icons'
-import { SOCIAL_ICONS } from '@data/types/icons'
+import { ICONS } from '@data/types/icons'
 
 interface FooterLink {
   label: string
@@ -19,17 +19,17 @@ interface Host {
 const footerData = {
   links: [
     {
-      label: SOCIAL_ICONS.spotify.label,
+      label: ICONS.spotify.label,
       href: 'https://open.spotify.com/show/331GnnQsHxjU7SjS1bFJnS?utm_medium=share&utm_source=linktree',
       icon: 'spotify',
     },
     {
-      label: SOCIAL_ICONS.applePodcasts.label,
+      label: ICONS.applePodcasts.label,
       href: 'https://podcasts.apple.com/us/podcast/%D7%9C%D7%90-%D7%98%D7%9B%D7%A0%D7%99-%D7%95%D7%9C%D7%90-%D7%91%D7%9E%D7%A7%D7%A8%D7%94/id1724399310',
       icon: 'applePodcasts',
     },
     {
-      label: SOCIAL_ICONS.youtube.label,
+      label: ICONS.youtube.label,
       href: 'https://www.youtube.com/@lotechni',
       icon: 'youtube',
     },
@@ -65,7 +65,7 @@ const footerData = {
             href={link.href}
             target="_blank"
             class="group flex flex-col items-center justify-center gap-2 text-accent hover:text-accent-light">
-            <Icon icon={link.icon} className={SOCIAL_ICONS[link.icon].hoverColor} />
+            <Icon icon={link.icon} className={ICONS[link.icon].hoverColor} />
             {link.label}
           </a>
         ))
@@ -81,7 +81,7 @@ const footerData = {
               href={host.href}
               target="_blank"
               class="group flex flex-col items-center justify-center gap-2 text-accent hover:text-accent-light">
-              <Icon icon={host.icon} className={SOCIAL_ICONS[host.icon].hoverColor} />
+              <Icon icon={host.icon} className={ICONS[host.icon].hoverColor} />
               {host.name}
             </a>
           ))

--- a/src/components/astro/Icon.astro
+++ b/src/components/astro/Icon.astro
@@ -1,7 +1,7 @@
 ---
 import { cn } from '@utils/cn'
 import type { IconNames, IconSize } from '@data/types/icons'
-import { SOCIAL_ICONS, ICON_SIZES } from '@data/types/icons'
+import { ICONS, ICON_SIZES } from '@data/types/icons'
 
 interface Props {
   icon: IconNames
@@ -12,7 +12,7 @@ interface Props {
 
 const { icon, size = 'md', className, label } = Astro.props
 
-const iconConfig = SOCIAL_ICONS[icon]
+const iconConfig = ICONS[icon]
 const ariaLabel = label || iconConfig.label
 ---
 

--- a/src/data/types/icons.ts
+++ b/src/data/types/icons.ts
@@ -6,7 +6,7 @@ export const ICON_SIZES = {
 
 export type IconSize = keyof typeof ICON_SIZES
 
-export const SOCIAL_ICONS = {
+export const ICONS = {
   spotify: {
     icon: 'icon-[tabler--brand-spotify]',
     label: 'Spotify',
@@ -37,10 +37,20 @@ export const SOCIAL_ICONS = {
     label: 'Website',
     hoverColor: 'group-hover:text-accent',
   },
+  chevronLeft: {
+    icon: 'icon-[tabler--chevron-left]',
+    label: 'Chevron Left',
+    hoverColor: 'group-hover:text-accent',
+  },
+  chevronRight: {
+    icon: 'icon-[tabler--chevron-right]',
+    label: 'Chevron Right',
+    hoverColor: 'group-hover:text-accent',
+  },
 }
 
-export type IconNames = keyof typeof SOCIAL_ICONS
-export type IconConfig = (typeof SOCIAL_ICONS)[IconNames]
+export type IconNames = keyof typeof ICONS
+export type IconConfig = (typeof ICONS)[IconNames]
 
 export interface SocialLink {
   icon: IconNames

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -57,3 +57,10 @@ const { title } = Astro.props
     animation: gradient-xy 4s linear infinite;
   }
 </style>
+
+<script>
+  import { initializeAllSliders } from '@utils/carousel'
+
+  // Initialize sliders on page load
+  document.addEventListener('DOMContentLoaded', initializeAllSliders)
+</script>

--- a/src/pages/testpage.astro
+++ b/src/pages/testpage.astro
@@ -8,6 +8,8 @@ import DemoImg from '@assets/images/tal.jpeg'
 import Heading from '@components/astro/typography/Heading.astro'
 import { Code } from 'astro:components'
 import { Image } from 'astro:assets'
+import Carousel from '@components/astro/Carousel.astro'
+
 const cards = [
   {
     title: 'Basic Card',
@@ -52,6 +54,12 @@ const imageContainers = [
     props: { showGradient: true, gradientOnlyOnHover: true },
   },
 ]
+
+// Generate 12 cards for testing
+const carouselCards = Array.from({ length: 12 }, (_, i) => ({
+  id: i + 1,
+  title: `Card ${i + 1}`,
+}))
 ---
 
 <Layout title="Test Page">
@@ -290,6 +298,135 @@ const imageContainers = [
             <Heading level={2} className="text-accent-light">Light Accent</Heading>
             <Heading level={2} className="text-accent-dark">Dark Accent</Heading>
           </div>
+        </div>
+      </CardContainer>
+    </div>
+  </SectionContainer>
+
+  <SectionContainer dir="ltr">
+    <div class="space-y-8">
+      <div class="max-w-3xl">
+        <Heading level={2} gradient>Carousel Component</Heading>
+        <p class="mt-4 text-lg text-gray-300">
+          A flexible carousel component built with Blaze Slider. Features responsive design,
+          customizable navigation, pagination, and auto-play capabilities.
+        </p>
+      </div>
+
+      <CardContainer>
+        <div class="space-y-4">
+          <Heading level={3} className="text-accent">Features</Heading>
+          <ul class="list-inside list-disc space-y-2">
+            <li>Responsive slides configuration for different screen sizes</li>
+            <li>Optional auto-play with customizable interval</li>
+            <li>Navigation controls and pagination dots</li>
+            <li>Group scrolling or single slide scrolling</li>
+            <li>Customizable transition duration and slide gap</li>
+          </ul>
+        </div>
+      </CardContainer>
+
+      <CardContainer>
+        <div class="space-y-4">
+          <Heading level={3} className="text-accent">Available Props</Heading>
+          <ul class="list-inside space-y-4">
+            <li>
+              <span class="font-semibold text-accent-light">sectionTitle</span>
+              <p class="ml-4 mt-1">Title shown above the carousel. Defaults to "Default Title"</p>
+            </li>
+            <li>
+              <span class="font-semibold text-accent-light">sectionLink</span>
+              <p class="ml-4 mt-1">Optional link for the title section. Defaults to "/"</p>
+            </li>
+            <li>
+              <span class="font-semibold text-accent-light">showPagination</span>
+              <p class="ml-4 mt-1">Shows/hides pagination dots. Defaults to true</p>
+            </li>
+            <li>
+              <span class="font-semibold text-accent-light">duration</span>
+              <p class="ml-4 mt-1">Slide transition duration in milliseconds. Defaults to 600</p>
+            </li>
+            <li>
+              <span class="font-semibold text-accent-light">slidesByWidth</span>
+              <p class="ml-4 mt-1">
+                Number of slides to show at different breakpoints. Defaults to {
+                  `{ mobile: 1, md: 2, lg: 3 }`
+                }
+              </p>
+            </li>
+            <li>
+              <span class="font-semibold text-accent-light">group</span>
+              <p class="ml-4 mt-1">Enable/disable group scrolling. Defaults to true</p>
+            </li>
+            <li>
+              <span class="font-semibold text-accent-light">autoPlay</span>
+              <p class="ml-4 mt-1">Enable/disable auto-play. Defaults to false</p>
+            </li>
+            <li>
+              <span class="font-semibold text-accent-light">autoplayInterval</span>
+              <p class="ml-4 mt-1">
+                Time between slides in milliseconds when auto-play is enabled. Defaults to 5000
+              </p>
+            </li>
+            <li>
+              <span class="font-semibold text-accent-light">hideTitle</span>
+              <p class="ml-4 mt-1">Hide the section title. Defaults to false</p>
+            </li>
+            <li>
+              <span class="font-semibold text-accent-light">hideControls</span>
+              <p class="ml-4 mt-1">Hide the navigation arrows. Defaults to false</p>
+            </li>
+            <li>
+              <span class="font-semibold text-accent-light">hideTop</span>
+              <p class="ml-4 mt-1">
+                Hide the entire top section (title and controls). Defaults to false
+              </p>
+            </li>
+            <li>
+              <span class="font-semibold text-accent-light">paginationClasses</span>
+              <p class="ml-4 mt-1">
+                Additional classes for the pagination container. Defaults to empty string
+              </p>
+            </li>
+          </ul>
+        </div>
+      </CardContainer>
+
+      <Carousel sectionTitle="Carousel Demo">
+        {
+          carouselCards.map((card) => (
+            <div class="flex aspect-video items-center justify-center rounded-lg bg-surface p-8">
+              <span class="text-2xl font-bold text-accent">{card.title}</span>
+            </div>
+          ))
+        }
+      </Carousel>
+
+      <CardContainer>
+        <div class="space-y-4">
+          <Heading level={2} className="text-accent">Usage Example</Heading>
+          <Code
+            code={`---
+import Carousel from '@components/astro/Carousel.astro'
+
+const slides = [1, 2, 3, 4, 5]
+---
+
+<Carousel
+  sectionTitle="My Carousel"
+  slidesByWidth={{ mobile: 1, md: 2, lg: 3 }}
+  autoPlay={true}
+  autoplayInterval={5000}
+>
+  {slides.map((slide) => (
+    <div class="your-slide-content">
+      Slide {slide}
+    </div>
+  ))}
+</Carousel>`}
+            lang="astro"
+            class="rounded-lg bg-surface p-4 text-sm"
+          />
         </div>
       </CardContainer>
     </div>

--- a/src/utils/carousel.ts
+++ b/src/utils/carousel.ts
@@ -1,0 +1,65 @@
+import BlazeSlider from 'blaze-slider'
+import type { BlazeConfig } from 'blaze-slider'
+import 'blaze-slider/dist/blaze.css'
+
+interface CarouselConfig {
+  duration: number
+  slides: {
+    mobile: number
+    md?: number
+    lg?: number
+  }
+  group: boolean
+  autoplay: boolean
+  autoplayInterval: number
+}
+
+export function initializeSlider(slider: HTMLElement) {
+  // Check if slider is already initialized
+  if (slider.dataset.carouselInitialized === 'true') return
+
+  const config: CarouselConfig = {
+    duration: Number(slider.dataset.duration) || 600,
+    slides: JSON.parse(slider.dataset.slides || '{"mobile": 1, "md": 2, "lg": 3}'),
+    group: slider.dataset.group === 'true',
+    autoplay: slider.dataset.autoplay === 'true',
+    autoplayInterval: Number(slider.dataset?.autoplayInterval) || 5000,
+  }
+
+  const blazeConfig: BlazeConfig = {
+    all: {
+      transitionDuration: config.duration,
+      slidesToShow: config.slides.mobile,
+      slidesToScroll: config.group ? config.slides.mobile : 1,
+      enablePagination: true,
+      slideGap: '1rem',
+      enableAutoplay: config.autoplay,
+      autoplayInterval: config.autoplay ? config.autoplayInterval : 0,
+    },
+    '(min-width: 768px)': {
+      slidesToShow: config.slides.md || config.slides.mobile,
+      slidesToScroll: config.group ? config.slides.md : 1,
+      slideGap: '1.25rem',
+    },
+    '(min-width: 1024px)': {
+      slidesToShow: config.slides.lg || config.slides.md || config.slides.mobile,
+      slidesToScroll: config.group ? config.slides.lg : 1,
+      slideGap: '1.5rem',
+    },
+  }
+
+  new BlazeSlider(slider, blazeConfig)
+  slider.dataset.carouselInitialized = 'true'
+}
+
+export function initializeAllSliders() {
+  document.querySelectorAll('.blaze-slider').forEach((slider) => {
+    if (slider instanceof HTMLElement) {
+      try {
+        initializeSlider(slider)
+      } catch (error) {
+        console.error('Error initializing Blaze Slider:', error)
+      }
+    }
+  })
+}


### PR DESCRIPTION
# Carousel Component

responsive carousel component built with Blaze Slider. Features customizable navigation, pagination, auto-play capabilities, and responsive slide configurations.

![CleanShot 2025-02-07 at 23 56 38](https://github.com/user-attachments/assets/837affd8-6fd9-47ab-8c37-cbe31e650f2e)


> [!NOTE]  
> we might not need all the options, but i have added the most usable options based on the [blaze-slider docs](https://blaze-slider.dev/docs/api/BlazeSlider).
> If towards the end we will se some unused ones we will set a default and remove them)

## Available props/customizations

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| sectionTitle | string | "Default Title" | Title shown above the carousel |
| sectionLink | string \| null | null | Optional link for the title section |
| showPagination | boolean | true | Shows/hides pagination dots |
| duration | number | 600 | Slide transition duration in milliseconds |
| slidesByWidth | object | `{ mobile: 1, md: 2, lg: 3 }` | Number of slides to show at different breakpoints |
| group | boolean | true | Enable/disable group scrolling |
| autoPlay | boolean | false | Enable/disable auto-play |
| autoplayInterval | number | 5000 | Time between slides in milliseconds when auto-play is enabled |
| hideTitle | boolean | false | Hide the section title |
| hideControls | boolean | false | Hide the navigation arrows |
| hideTop | boolean | false | Hide the entire top section (title and controls) |
| paginationClasses | string | "" | Additional classes for the pagination container |

---

> [!TIP]  
> Full demo with prop list and usage demo available at the `/testpage` route