### PR TITLE
Feat/episode page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,5 +9,6 @@ export default defineConfig({
   adapter: vercel({
     imageService: true,
   }),
+  prefetch: { prefetchAll: true },
   output: 'server',
 })

--- a/src/components/astro/Button.astro
+++ b/src/components/astro/Button.astro
@@ -1,6 +1,7 @@
 ---
 interface Props {
   variant?: 'button' | 'link'
+  size?: 'sm' | 'md' | 'lg' | 'xl'
   href?: string
   onClick?: string
   class?: string
@@ -10,29 +11,33 @@ interface Props {
 
 const {
   variant = 'button',
+  size = 'md',
   href,
   onClick,
   class: className = '',
-  target,
-  rel,
 } = Astro.props
 
-const baseStyles = "inline-flex justify-center rounded-lg bg-accent px-4 py-2 text-white hover:bg-accent/80 transition-colors"
+const sizeStyles = {
+  sm: 'px-4 py-2 text-sm',
+  md: 'px-5 py-2.5 text-base',
+  lg: 'px-6 py-3 text-lg',
+  xl: 'px-7 py-4 text-xl'
+}
+
+const baseStyles = "inline-flex justify-center rounded-lg bg-accent hover:bg-accent/80 transition-colors hover:scale-105 transition-transform duration-200"
 ---
 
 {variant === 'link' ? (
   <a
     href={href}
-    target={target}
-    rel={rel}
-    class:list={[baseStyles, className]}
+    class:list={[baseStyles, sizeStyles[size], className]}
   >
     <slot />
   </a>
 ) : (
   <button
     onclick={onClick}
-    class:list={[baseStyles, className]}
+    class:list={[baseStyles, sizeStyles[size], className]}
   >
     <slot />
   </button>

--- a/src/components/astro/EpisodeCard.astro
+++ b/src/components/astro/EpisodeCard.astro
@@ -2,9 +2,11 @@
 import EpisodeCardDescription from '@components/react/EpisodeCardDescription'
 import type { Episode } from '@data/types/spotifyEpisodes'
 
-interface Props extends Episode {}
+interface Props extends Episode {
+  expandable?: boolean
+}
 
-const { name, description, html_description, images, id } = Astro.props
+const { name, description, html_description, images, id, expandable = true } = Astro.props
 ---
 
 <div
@@ -30,6 +32,7 @@ const { name, description, html_description, images, id } = Astro.props
   <EpisodeCardDescription
     description={description}
     html_description={html_description}
+    expandable={expandable}
     client:load
   />
 </div>

--- a/src/components/react/EpisodeCardDescription.tsx
+++ b/src/components/react/EpisodeCardDescription.tsx
@@ -4,29 +4,33 @@ import { useState } from 'react'
 interface EpisodeCardDescriptionProps {
   description?: string
   html_description?: string
+  expandable?: boolean
 }
 
 export default function EpisodeCardDescription({
   description,
   html_description,
+  expandable = true,
 }: EpisodeCardDescriptionProps) {
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(!expandable)
 
   return (
     <div
-      className="mt-2 flex cursor-pointer items-center justify-between"
-      onClick={() => setOpen(!open)}>
+      className={cn('mt-2 flex items-center justify-between', expandable && 'cursor-pointer')}
+      onClick={() => expandable && setOpen(!open)}>
       {open && html_description ? (
         <div className="mt-2 inline-block" dangerouslySetInnerHTML={{ __html: html_description }} />
       ) : (
-        <span className="line-clamp-3">{description}</span>
+        <span className={cn('line-clamp-3', !expandable && 'line-clamp-none')}>{description}</span>
       )}
-      <span
-        className={cn(
-          'icon-[tabler--caret-down-filled] sticky top-24 min-w-8 self-start text-current transition-transform duration-200',
-          open && 'rotate-180'
-        )}
-      />
+      {expandable && (
+        <span
+          className={cn(
+            'icon-[tabler--caret-down-filled] sticky top-24 min-w-8 self-start text-current transition-transform duration-200',
+            open && 'rotate-180'
+          )}
+        />
+      )}
     </div>
   )
 }

--- a/src/pages/episodes/[id].astro
+++ b/src/pages/episodes/[id].astro
@@ -1,15 +1,25 @@
 ---
 import Layout from '@layouts/Layout.astro'
 import SectionContainer from '@components/astro/containers/SectionContainer.astro'
+import { fetchShowData } from '@utils/spotify'
+import EpisodeCard from '@components/astro/EpisodeCard.astro'
+import Logo from '@components/astro/Logo.astro'
 
 const { id } = Astro.params
-const title = `Episode ${id}`
+const show = await fetchShowData(import.meta.env.PUBLIC_SPOTIFY_SHOW_ID)
+const lastIndex = show.episodes.items.length - 1
+const episode = show.episodes.items[lastIndex - parseInt(id ?? '0')]
+
+if (!episode) {
+  return Astro.redirect('/404')
+}
+
+const title = episode.name
 ---
 
 <Layout title={title}>
+  <Logo showName={show.name} />
   <SectionContainer>
-    <h1 class="text-center text-4xl font-bold">
-      This is <span class="text-gradient">{title}</span> page
-    </h1>
+    <EpisodeCard {...episode} expandable={false} />
   </SectionContainer>
 </Layout>

--- a/src/pages/episodes/index.astro
+++ b/src/pages/episodes/index.astro
@@ -7,14 +7,11 @@ import Heading from '@components/astro/typography/Heading.astro'
 // import DescriptionCard from '../../components/DescriptionCard.astro'
 // import Speakers from '../../components/Speakers.astro'
 import Logo from '@components/astro/Logo.astro'
+import EpisodesGrid from '@sections/episodes/EpisodesGrid.astro'
 const show = await fetchShowData(import.meta.env.PUBLIC_SPOTIFY_SHOW_ID)
-const parsedEpisodes = show.episodes.items
 ---
 
 <Layout title={show.name}>
   <Logo showName={show.name} />
-  <Heading level={2} className="text-gradient">פרקים</Heading>
-  <ul role="list" class="mx-auto grid max-w-7xl grid-cols-1 gap-8 p-0 md:grid-cols-2">
-    {parsedEpisodes?.map((episode) => <EpisodeCard {...episode} />)}
-  </ul>
+  <EpisodesGrid />
 </Layout>

--- a/src/pages/episodes/index.astro
+++ b/src/pages/episodes/index.astro
@@ -2,6 +2,7 @@
 import Layout from '@layouts/Layout.astro'
 import { fetchShowData } from '@utils/spotify'
 import EpisodeCard from '@components/astro/EpisodeCard.astro'
+import Heading from '@components/astro/typography/Heading.astro'
 // No unused vars errors - to be added back when used
 // import DescriptionCard from '../../components/DescriptionCard.astro'
 // import Speakers from '../../components/Speakers.astro'
@@ -12,7 +13,7 @@ const parsedEpisodes = show.episodes.items
 
 <Layout title={show.name}>
   <Logo showName={show.name} />
-  <h2 class="text-gradient">פרקים</h2>
+  <Heading level={2} className="text-gradient">פרקים</Heading>
   <ul role="list" class="mx-auto grid max-w-7xl grid-cols-1 gap-8 p-0 md:grid-cols-2">
     {parsedEpisodes?.map((episode) => <EpisodeCard {...episode} />)}
   </ul>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import DescriptionCard from '@components/astro/DescriptionCard.astro'
 import Logo from '@components/astro/Logo.astro'
 import SuccessStories from '@sections/our-story/SuccessStories.astro'
 import CommunityCard from '@components/astro/CommunityCard.astro'
+import Heading from '@components/astro/typography/Heading.astro'
 const show = await fetchShowData(import.meta.env.PUBLIC_SPOTIFY_SHOW_ID)
 
 let parsedEpisodes = show.episodes.items.slice(0, 4)
@@ -26,9 +27,13 @@ let parsedEpisodes = show.episodes.items.slice(0, 4)
   <!-- Todo: Extract episodes to a separate Section -->
 
   <div class="container space-y-12 py-8 text-xl leading-relaxed">
+    <Heading level={2} className="text-center">הפרקים האחרונים</Heading>
     <ul role="list" class="mx-auto grid max-w-7xl grid-cols-1 gap-8 p-0 md:grid-cols-2">
       {parsedEpisodes.map((episode) => <EpisodeCard {...episode} />)}
     </ul>
+  </div>ֿֿ
+
+  <div class="container space-y-12 py-8 text-xl leading-relaxed">
     <CommunityCard />
   </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,8 @@ import Logo from '@components/astro/Logo.astro'
 import SuccessStories from '@sections/our-story/SuccessStories.astro'
 import CommunityCard from '@components/astro/CommunityCard.astro'
 import Heading from '@components/astro/typography/Heading.astro'
+import EpisodesGrid from '@sections/episodes/EpisodesGrid.astro'
+import Button from '@components/astro/Button.astro'
 const show = await fetchShowData(import.meta.env.PUBLIC_SPOTIFY_SHOW_ID)
 
 let parsedEpisodes = show.episodes.items.slice(0, 4)
@@ -15,7 +17,6 @@ let parsedEpisodes = show.episodes.items.slice(0, 4)
 
 <Layout title={show.name}>
   <Logo showName={show.name} />
-  <!-- Todo: Extract description to a separate Section -->
 
   <div class="container space-y-12 py-8 text-xl leading-relaxed">
     <DescriptionCard>
@@ -24,14 +25,14 @@ let parsedEpisodes = show.episodes.items.slice(0, 4)
   </div>
 
   <Hosts />
-  <!-- Todo: Extract episodes to a separate Section -->
 
-  <div class="container space-y-12 py-8 text-xl leading-relaxed">
-    <Heading level={2} className="text-center">הפרקים האחרונים</Heading>
-    <ul role="list" class="mx-auto grid max-w-7xl grid-cols-1 gap-8 p-0 md:grid-cols-2">
-      {parsedEpisodes.map((episode) => <EpisodeCard {...episode} />)}
-    </ul>
-  </div>ֿֿ
+  <EpisodesGrid compact />
+
+  <div class="container space-y-12 py-8 text-xl leading-relaxed flex justify-center">
+    <Button size='xl' variant='link' class='flex items-center gap-2' href="/episodes"><span class="icon-[tabler--headphones]"></span>לכל הפרקים
+    
+    </Button>
+  </div>
 
   <div class="container space-y-12 py-8 text-xl leading-relaxed">
     <CommunityCard />

--- a/src/sections/episodes/EpisodesGrid.astro
+++ b/src/sections/episodes/EpisodesGrid.astro
@@ -1,0 +1,23 @@
+---
+import Heading from '@components/astro/typography/Heading.astro'
+import EpisodeCard from '@components/astro/EpisodeCard.astro'
+import { fetchShowData } from '@utils/spotify'
+
+interface Props {
+  compact?: boolean
+}
+
+const { compact = false } = Astro.props
+const show = await fetchShowData(import.meta.env.PUBLIC_SPOTIFY_SHOW_ID)
+const parsedEpisodes = show.episodes.items
+
+const sectionTitle = compact ? 'הפרקים האחרונים' : 'פרקים'
+const shownEpisodes = compact ? parsedEpisodes.slice(0, 4) : parsedEpisodes
+---
+
+<div class="container space-y-12 py-8 text-xl leading-relaxed">
+  <Heading level={2} className="text-center">{sectionTitle}</Heading>
+  <ul role="list" class="mx-auto grid max-w-7xl grid-cols-1 gap-8 p-0 md:grid-cols-2">
+    {shownEpisodes.map((episode) => <EpisodeCard {...episode} />)}
+  </ul>
+</div> 


### PR DESCRIPTION

# 🎯 Changes Overview

## Button Component Enhancements
- Added size variants (`sm`, `md`, `lg`, `xl`) to the Button component
- Improved button styling with scale animation on hover
- Removed unused `target` and `rel` props
- Standardized padding and text sizes across variants

## Episode Related Changes
### New Features
- Created dedicated episode page (`[id].astro`)
- Added `EpisodesGrid` component for better organization
- Implemented expandable/collapsible episode descriptions
- Added compact view option for episodes list

### UI/UX Improvements
- Episode cards now have an expandable/collapsible description
- Added navigation to full episodes list
- Improved homepage layout with recent episodes section
- Added "View All Episodes" button with headphones icon

## Code Organization
- Extracted episodes grid logic into a dedicated component
- Improved component props typing
- Better separation of concerns between components

## Breaking Changes
- None. All changes are backwards compatible

---
