### PR TITLE
47-fix-the-accordion-behavior-the-content-height-should-increase-only-for-the-opened-item

### DIFF
--- a/src/components/astro/EpisodeCard.astro
+++ b/src/components/astro/EpisodeCard.astro
@@ -15,7 +15,7 @@ const cleanedHtmlDescription = cleanHtmlContent(html_description)
 ---
 
 <div
-  class="flex flex-col overflow-hidden scrollbar-hide rounded-lg bg-surface p-6 text-base text-white shadow-inner shadow-white/10"
+  class="flex flex-col overflow-hidden scrollbar-hide rounded-lg bg-surface h-min p-6 text-base text-white shadow-inner shadow-white/10"
   >
   <div class="pb-5 overflow-hidden scrollbar-hide space-y-4">
     {id ? (


### PR DESCRIPTION
Fix: Adjust `EpisodeCard` height to match the minimum content height, resolving the bug where non-expanded cards were increasing in height due to adjacent expanded cards.

Before:
<img width="1159" alt="Screenshot 2025-02-16 at 23 36 04" src="https://github.com/user-attachments/assets/11086240-3dcf-4efd-a442-c3f0ad15042b" />


After:
<img width="1157" alt="Screenshot 2025-02-16 at 23 35 11" src="https://github.com/user-attachments/assets/612f9b52-5680-4ca7-81d4-11e293e9af23" />

related to this issue:
https://github.com/talmosko/lotechni.dev/issues/47
