### PR TITLE
fix: remove HTML tags from episode description

### DIFF
--- a/src/components/react/EpisodeCardDescription.tsx
+++ b/src/components/react/EpisodeCardDescription.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@utils/cn'
+import { cleanHtmlContent } from '@utils/text'
 import { useState } from 'react'
 
 interface EpisodeCardDescriptionProps {
@@ -30,7 +31,7 @@ export default function EpisodeCardDescription({
         {open && html_description ? (
           <div dangerouslySetInnerHTML={{ __html: html_description }} />
         ) : (
-          <p className={cn('line-clamp-3', !expandable && 'line-clamp-none')}>{description}</p>
+          <p className={cn('line-clamp-3', !expandable && 'line-clamp-none')}>{description ? cleanHtmlContent(description) : ''}</p>
         )}
       </div>
     </div>

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,0 +1,3 @@
+export function cleanHtmlContent(html: string): string {
+  return html.replace(/<[^>]*>/g, '');
+}


### PR DESCRIPTION
This PR removes HTML tags from episode descriptions in closed cards