### PR TITLE
Slug-based URLs לפרקי לא פורמלי + תיקון HTML בכרטיסייה סגורה

### DIFF
--- a/src/components/astro/EpisodeCard.astro
+++ b/src/components/astro/EpisodeCard.astro
@@ -21,7 +21,7 @@ const {
   description,
   html_description,
   images,
-  episode_number,
+  slug,
   release_date,
   iframe_url,
   thumbnail_url,
@@ -29,7 +29,7 @@ const {
   show_iframe = true,
   clickable = true,
 } = Astro.props
-const episodeUrl = `/episodes/${episode_number}`
+const episodeUrl = `/episodes/${slug}`
 const cleanedHtmlDescription = cleanHtmlContent(html_description)
 ---
 
@@ -68,7 +68,7 @@ const cleanedHtmlDescription = cleanHtmlContent(html_description)
   </div>
   <div class="flex items-center justify-between border-b border-white/10 pb-4">
     <CardDate date={release_date} />
-    <EpisodeShareButton show_number={episode_number} episode_name={name} />
+    <EpisodeShareButton show_number={slug} episode_name={name} />
   </div>
 
   <EpisodeCardDescription

--- a/src/components/react/EpisodeCardDescription.tsx
+++ b/src/components/react/EpisodeCardDescription.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@utils/cn'
-import { cleanHtmlContent } from '@utils/cleanHtml'
+import { stripHtmlTags } from '@utils/cleanHtml'
 import { useState } from 'react'
 
 interface EpisodeCardDescriptionProps {
@@ -31,7 +31,7 @@ export default function EpisodeCardDescription({
         {open && html_description ? (
           <div dangerouslySetInnerHTML={{ __html: html_description }} />
         ) : (
-          <p className={cn('line-clamp-3', !expandable && 'line-clamp-none')}>{description ? cleanHtmlContent(description) : ''}</p>
+          <p className={cn('line-clamp-3', !expandable && 'line-clamp-none')}>{description ? stripHtmlTags(description) : ''}</p>
         )}
       </div>
     </div>

--- a/src/data/seo/defaultSeo.ts
+++ b/src/data/seo/defaultSeo.ts
@@ -54,7 +54,7 @@ export const getEpisodeSEO = (episode: Episode): Partial<SEOProps> => {
         title: episode.name,
         type: 'article',
         image: episode.thumbnail_url || episode.images[0].url || '',
-        url: `${SITE_URL}/episodes/${episode.episode_number}`,
+        url: `${SITE_URL}/episodes/${episode.slug}`,
       },
       optional: {
         description: episode.description.substring(0, 155) + '...',

--- a/src/data/types/spotifyEpisodes.ts
+++ b/src/data/types/spotifyEpisodes.ts
@@ -52,6 +52,7 @@ const EpisodeSchemaWithNumber = episodeSchema.extend({
   iframe_url: z.string(),
   embed_url: z.string(),
   thumbnail_url: z.string().optional(),
+  slug: z.string(),
 })
 
 const SpotifyEpisodesResponseSchema = z.object({

--- a/src/pages/episodes/[id].astro
+++ b/src/pages/episodes/[id].astro
@@ -15,7 +15,7 @@ const show = await getShowData()
 if (!show || !id) {
   throw new Error('No show data found')
 }
-const episode = show.episodes.items.find((episode) => episode.episode_number === parseInt(id))
+const episode = show.episodes.items.find((episode) => episode.slug === id)
 
 if (!episode) {
   return Astro.redirect('/404')
@@ -27,7 +27,7 @@ const episodeSEO = getEpisodeSEO(episode)
 export const getStaticPaths = async () => {
   const _show = await getShowData()
   return _show?.episodes.items.map((episode) => ({
-    params: { id: episode.episode_number.toString() },
+    params: { id: episode.slug },
   }))
 }
 ---
@@ -40,7 +40,7 @@ export const getStaticPaths = async () => {
 
   <SectionContainer>
     <Heading level={2} className="mb-8 text-center">גם הפרקים האלה נייס</Heading>
-    <EpisodesGrid compact excludeEpisode={episode.episode_number} />
+    <EpisodesGrid compact excludeSlug={episode.slug} />
   </SectionContainer>
 
   <NewsletterSubscribe />

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -45,7 +45,7 @@ async function generateSitemapXml(baseUrl: string) {
     .map(
       (episode) => `
   <url>
-    <loc>${formatUrl(baseUrl, `episodes/${episode.episode_number}`)}</loc>
+    <loc>${formatUrl(baseUrl, `episodes/${episode.slug}`)}</loc>
     <lastmod>${formatDate(episode.release_date)}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/src/sections/episodes/EpisodesGrid.astro
+++ b/src/sections/episodes/EpisodesGrid.astro
@@ -2,10 +2,10 @@
 import EpisodeCard from '@components/astro/EpisodeCard.astro'
 interface Props {
   compact?: boolean
-  excludeEpisode?: number
+  excludeSlug?: string
 }
 
-const { compact = false, excludeEpisode } = Astro.props
+const { compact = false, excludeSlug } = Astro.props
 import { getShowData } from '@stores/episodes'
 import Button from '@components/astro/Button.astro'
 import Icon from '@components/astro/Icon.astro'
@@ -15,12 +15,12 @@ if (!show) {
   throw new Error('No show data found')
 }
 let parsedEpisodes = show.episodes.items
-if (excludeEpisode) {
-  parsedEpisodes = parsedEpisodes.filter((episode) => episode.episode_number !== excludeEpisode)
+if (excludeSlug) {
+  parsedEpisodes = parsedEpisodes.filter((episode) => episode.slug !== excludeSlug)
 }
 
 const shownEpisodes = compact
-  ? excludeEpisode
+  ? excludeSlug
     ? parsedEpisodes.sort(() => Math.random() - 0.5).slice(0, 4)
     : parsedEpisodes.slice(0, 4)
   : parsedEpisodes

--- a/src/utils/cleanHtml.ts
+++ b/src/utils/cleanHtml.ts
@@ -2,9 +2,8 @@
  * Cleans HTML content by removing unwanted elements and normalizing spacing
  * such as <br> tags, while preserving them before links.
  * @param html The HTML content to clean
- * @returns The cleaned HTML content
+ * @returns The cleaned HTML content (still valid HTML)
  */
-
 export function cleanHtmlContent(html?: string) {
   if (!html) return html
 
@@ -22,4 +21,25 @@ export function cleanHtmlContent(html?: string) {
       .replace(/___PRESERVE_BR___/g, '<br>')
       .trim()
   )
+}
+
+/**
+ * Strips all HTML tags from a string, returning plain text only.
+ * Useful for displaying HTML content in plain text contexts
+ * (e.g. closed/collapsed card descriptions).
+ * @param html The HTML content to strip
+ * @returns The plain text content without any HTML tags
+ */
+export function stripHtmlTags(html?: string) {
+  if (!html) return html
+  return html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim()
 }

--- a/src/utils/spotify.ts
+++ b/src/utils/spotify.ts
@@ -12,6 +12,19 @@ function extractEpisodeNumber(title: string): number | null {
   return match ? parseInt(match[1]) : null
 }
 
+/**
+ * Determines if an episode belongs to the "לא פורמלי" secondary series
+ * and extracts its sub-number.
+ * Returns { isLf: true, lfNumber: N } for "לא פורמלי" / "לא פורמאלי" episodes,
+ * or { isLf: false } for regular episodes.
+ */
+function parseLfInfo(title: string): { isLf: boolean; lfNumber?: number } {
+  const isLf = /לא פורמלי|לא פורמאלי/i.test(title)
+  if (!isLf) return { isLf: false }
+  const match = title.match(/\{(\d+)\}/)
+  return { isLf: true, lfNumber: match ? parseInt(match[1]) : 0 }
+}
+
 async function getRssFeed() {
   const res = await fetch('https://anchor.fm/s/f01f6814/podcast/rss')
   const xml = await res.text()
@@ -67,6 +80,10 @@ export async function fetchShowData() {
 
   const episodeItems = items.map((item, index) => {
     const episodeNumber = extractEpisodeNumber(item.title)
+    const lfInfo = parseLfInfo(item.title)
+    const slug = lfInfo.isLf
+      ? `lf-${lfInfo.lfNumber}`
+      : episodeNumber?.toString() ?? ''
 
     const spotify = spotifyData[index]
     const iframeUrl = spotify?.embedUrl || buildAnchorEmbedUrl(item.link || '')
@@ -84,6 +101,7 @@ export async function fetchShowData() {
       release_date_precision: 'day',
       images: [{ url: thumbnailUrl, height: null, width: null }],
       episode_number: episodeNumber ?? -1,
+      slug,
       iframe_url: iframeUrl,
       embed_url: iframeUrl,
       thumbnail_url: thumbnailUrl,
@@ -92,10 +110,10 @@ export async function fetchShowData() {
     }
   })
 
-  // Filter out items without a valid episode number (announcements, vote callouts, etc.)
+  // Filter out items without a valid episode number or slug (announcements, vote callouts, etc.)
   const liveEpisodes = episodeItems.filter(
     (ep) =>
-      ep.episode_number >= 0 &&
+      (ep.episode_number >= 0 || ep.slug.startsWith('lf-')) &&
       !EXCLUDED_TITLE_PATTERNS.some((pattern) => pattern.test(ep.name))
   )
 


### PR DESCRIPTION
## שינויים

### 🐛 תיקון HTML בתצוגה הסגורה של EpisodeCard
- הוספת פונקציה `stripHtmlTags()` ב-utils/cleanHtml שמסירה את כל תגיות ה-HTML
- `EpisodeCardDescription` משתמשת ב-stripHtmlTags במצב סגור (במקום cleanHtmlContent שמסיר רק <br>)
- cleanHtmlContent נשארה כפי שהיא לשימושים אחרים (ניוזלטר, תצוגה פתוחה)

### ✨ סלאג לפרקי "לא פורמלי"
- הוספת שדה `slug` ל-Episode type
- פונקציה `parseLfInfo()` שמזהה פרקים עם "לא פורמלי"/"לא פורמאלי" בכותרת
- פרקים רגילים: slug = מספר פרק (למשל `49`)
- פרקי "לא פורמלי": slug = `lf-N` (למשל `lf-0`)
- עדכון כל ההפניות ל-URL: EpisodeCard, EpisodesGrid, [id].astro, sitemap, SEO, share button

### קבצים שנגעו
- src/utils/cleanHtml.ts
- src/utils/spotify.ts
- src/data/types/spotifyEpisodes.ts
- src/components/astro/EpisodeCard.astro
- src/components/react/EpisodeCardDescription.tsx
- src/pages/episodes/[id].astro
- src/pages/sitemap.xml.ts
- src/sections/episodes/EpisodesGrid.astro
- src/data/seo/defaultSeo.ts